### PR TITLE
Fix setup.py import error by isolating __version__

### DIFF
--- a/cocoatree/__init__.py
+++ b/cocoatree/__init__.py
@@ -4,3 +4,6 @@ from . import statistics
 from . import io
 from . import deconvolution
 from ._pipeline import perform_sca
+
+
+__version__ = "0.0.0a0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
 from setuptools import setup, find_packages
-version = {}
-with open("cocoatree/_version.py") as f: exec(f.read(), version)
 
 long_description = "Long description of the awesome coevolution package"
 
 setup(
     name='cocoatree',
-    version=version["__version__"],
+    version="0.0.0a0.dev0",
     description='Awesome coevolution stuff',  # Optional
     long_description=long_description,  # Optional
     long_description_content_type='text/markdown',  # Optional (see note above)


### PR DESCRIPTION
This PR fixes an installation error caused by importing __version__ directly from the cocoatree package in setup.py. 
The __version__ variable has been moved into a dedicated version.py file that contains no imports.